### PR TITLE
Removing mentions of promos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pokemon TCG Pocket Luck Calculator
+# Pokemon TCG Pocket Pack Luck Calculator
 
 This fan-made calculator uses some simple HTML/CSS/JS to determine how lucky PTCGP players have been with their packs and cards.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pokemon TCG Pocket Pack Luck Calculator
+# Pokemon TCG Pocket Luck Calculator
 
 This fan-made calculator uses some simple HTML/CSS/JS to determine how lucky PTCGP players have been with their packs and cards.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This fan-made calculator uses some simple HTML/CSS/JS to determine how lucky PTC
 Feel free to submit a PR if you'd like to contribute.
 
 Open issues:
- - Users have to exclude cards they received from wonder packs
+ - Users have to exclude cards they received from wonder picks
  - Users have to manually add cards they converted to items back to their count
  - The binomial probability calculations are a bit off since a single pack can yield multiple rare cards

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This fan-made calculator uses some simple HTML/CSS/JS to determine how lucky PTC
 Feel free to submit a PR if you'd like to contribute.
 
 Open issues:
- - Users have to exclude cards they received from promos or wonder packs
+ - Users have to exclude cards they received from wonder packs
  - Users have to manually add cards they converted to items back to their count
  - The binomial probability calculations are a bit off since a single pack can yield multiple rare cards

--- a/index.html
+++ b/index.html
@@ -197,16 +197,23 @@
             const rarePackRate = 1/2000;
             const normalPackRate = 1 - rarePackRate;
             const cardsPerPack = 5;
-            const numSeries = 3;
+            const setThreeMult = 2.5;
+            const setTwoMult = 1.75;
+            const setOneMult = 1;
+            const numSetThree = 1;
+            const numSetTwo = 1;
+            const numSetOne = 2;
+            const setAverageDivisor = (setThreeMult * numSetThree) + (setTwoMult * numSetTwo) + (setOneMult * numSetOne)
             const typeKeys = {'crown':'cr', 'three star':'3s', 'two star':'2s', 'one star':'1s', 'rare':'rare', 'four diamond':'4d'};
             const rarity = typeKeys[cardType];
 
             const rates = {
-                'norm' : {'4th' : {'cr':0.040/100, '3s':0.888/100, '2s': 0.500/100, '1s': 2.572/100, '4d': 1.666/100},
-                          '5th' : {'cr':0.160/100, '3s':0.222/100, '2s': 2.000/100, '1s':10.288/100, '4d': 6.664/100}},
-                'rare' : {'a1'  : {'cr':3.846/100, '3s':3.846/100, '2s':47.368/100, '1s':42.105/100, '4d': 0.000/100},
+                'norm' : {'4th' : {'cr':0.040/100, '3s':0.222/100, '2s': 0.500/100, '1s': 2.572/100, '4d': 1.666/100},
+                          '5th' : {'cr':0.160/100, '3s':0.888/100, '2s': 2.000/100, '1s':10.288/100, '4d': 6.664/100}},
+                'rare' : {'a1'  : {'cr':5.088/100, '3s':5.088/100, '2s':49.122/100, '1s':40.702/100, '4d': 0.000/100},
                           'a1a' : {'cr':5.555/100, '3s':5.555/100, '2s':55.555/100, '1s':33.333/100, '4d': 0.000/100},
-                          'a2'  : {'cr':5.263/100, '3s':5.263/100, '2s':46.153/100, '1s':46.153/100, '4d': 0.000/100}}
+                          'a2'  : {'cr':5.263/100, '3s':5.263/100, '2s':46.153/100, '1s':46.153/100, '4d': 0.000/100},
+                          'a2a' : {'cr':4.761/100, '3s':4.761/100, '2s':61.904/100, '1s':28.571/100, '4d': 0.000/100}}
             };
 
             // Note: this makes a simplifying assumption that the user has opened
@@ -214,18 +221,26 @@
             // always fair, the resulting error is likely much less than the error
             // introduced by the many other existing issues and/or assumptions.
 
+            // Note: I adjusted the next two formulas so those are now weighted using the set[Number]Mult variables.
+            // This probably still isnt perfect, but should be more accurate. If you are wondering how I got those 
+            // multipliers, I added 20 to the dex size of each set, then divided all of those numbers by the new number
+            // for the smallest set. I then adjusted the numbers a VERY small amount to clean it up to these nice numbers.
+            // The a1 rare values are an average of all three packs, and the other sets (up to a2a) dont need averaged.
+
             const rate = ((cardType == 'rare') ? rarePackRate :
                 normalPackRate * (1 - (1 -  rates['norm']['4th'][rarity]) * 
                                       (1 -  rates['norm']['5th'][rarity])) + 
-                  rarePackRate * (1 - (1 - (rates['rare'][ 'a1'][rarity] + 
-                                            rates['rare']['a1a'][rarity] +
-                                            rates['rare'][ 'a2'][rarity]) / numSeries) ** cardsPerPack));
+                  rarePackRate * (1 - (1 - ((rates['rare'][ 'a1'][rarity] * setThreeMult) + 
+                                            (rates['rare']['a1a'][rarity] * setOneMult) +
+                                            (rates['rare'][ 'a2'][rarity] * setTwoMult) +
+                                            (rates['rare']['a2a'][rarity] * setOneMult) / setAverageDivisor) ** cardsPerPack));
 
             const expCardsPerPack = ((cardType == 'rare') ? rate :
             	normalPackRate * (rates['norm']['4th'][rarity] + rates['norm']['5th'][rarity]) +
-            	  rarePackRate *((rates['rare'][ 'a1'][rarity] + 
-            	  	              rates['rare']['a1a'][rarity] +
-                                  rates['rare'][ 'a2'][rarity]) / numSeries) * cardsPerPack);
+            	  rarePackRate *(((rates['rare'][ 'a1'][rarity] * setThreeMult) + 
+                                  (rates['rare']['a1a'][rarity] * setOneMult) +
+                                  (rates['rare'][ 'a2'][rarity] * setTwoMult) +
+                                  (rates['rare']['a2a'][rarity] * setOneMult) / setAverageDivisor) * cardsPerPack);
 
             numCardsInput = document.getElementById(`${rarity}Cards`).value;
             resultElement = document.getElementById(`${rarity}Result`);

--- a/index.html
+++ b/index.html
@@ -160,13 +160,13 @@
             <h1 style="text-align: center;"><br><br>How to Find Your Stats</h1>
             <div class="image-gallery" style="display: flex; flex-direction: column; align-items: center; gap: 20px; margin-top: 20px;">
                 <img src="images/packs.png"   alt="packs image"   style="width: 320px; height: auto;"/>
-                <label class="sublabel">Check your packs trophy to find your number of opened packs.<br>Yes, this trophy does count packs opened with hourglasses!<br>This means that you have to add any packs earned from event missions.<br>As of March 15, 2025, there have been 16 event packs available to be earned this way, three of which had one card guaranteed to be ♦♦♦♦ or better</label>
+                <label class="sublabel">Check your packs trophy to find your number of opened packs.<br>Yes, this trophy does count packs opened with hourglasses!<br>This means that you have to add any packs earned from event missions.<br>As of March 15, 2025, there have been 16 event packs available to be<br>earned this way, three of which had one card guaranteed to be ♦♦♦♦ or better</label>
                 <img src="images/search1.png" alt="search1 image" style="width: 320px; height: auto;"/>
                 <label class="sublabel">Use the search function to find your number of cards.</label>
                 <img src="images/search2.png" alt="search2 image" style="width: 320px; height: auto;"/>
                 <label class="sublabel">Use the filter to select a given card rarity.</label>
                 <img src="images/search3.png" alt="search3 image" style="width: 320px; height: auto;"/>
-                <label class="sublabel">Check the resulting count to find your number of cards of that rarity.<br>Try to exclude cards you received from wonder picks or purchased with pack points.</label>
+                <label class="sublabel">Check the resulting count to find your number of cards of that rarity.<br>Try to exclude cards you received from wonder picks or pack points.</label>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
     <div class="container">
         <h1>Pokémon TCG Pocket Luck Calculator</h1>
         <div class="section">
-            <label class="label"><br>Enter the number of cards you have pulled<br>(try to exclude cards from wonder picks)<br><br></label>
+            <label class="label"><br>Enter the number of cards you have pulled<br>(try to exclude cards from wonder picks and pack points)<br><br></label>
             <div class="input-group">
                 <label class="prompt">Number of 👑 cards:</label>
                 <input type="number" id="crCards" placeholder="Enter value..." min="0" max="1000"/>
@@ -160,13 +160,13 @@
             <h1 style="text-align: center;"><br><br>How to Find Your Stats</h1>
             <div class="image-gallery" style="display: flex; flex-direction: column; align-items: center; gap: 20px; margin-top: 20px;">
                 <img src="images/packs.png"   alt="packs image"   style="width: 320px; height: auto;"/>
-                <label class="sublabel">Check your packs trophy to find your number of opened packs.<br>Yes, this trophy does count packs opened with hourglasses!</label>
+                <label class="sublabel">Check your packs trophy to find your number of opened packs.<br>Yes, this trophy does count packs opened with hourglasses!<br>This means that you have to add any packs earned from event missions.<br>As of March 15, 2025, there have been 16 event packs available to be earned this way, three of which had one card guaranteed to be ♦♦♦♦ or better</label>
                 <img src="images/search1.png" alt="search1 image" style="width: 320px; height: auto;"/>
                 <label class="sublabel">Use the search function to find your number of cards.</label>
                 <img src="images/search2.png" alt="search2 image" style="width: 320px; height: auto;"/>
                 <label class="sublabel">Use the filter to select a given card rarity.</label>
                 <img src="images/search3.png" alt="search3 image" style="width: 320px; height: auto;"/>
-                <label class="sublabel">Check the resulting count to find your number of cards of that rarity.<br>Try to exclude cards you received from wonder picks or promos.</label>
+                <label class="sublabel">Check the resulting count to find your number of cards of that rarity.<br>Try to exclude cards you received from wonder picks or purchased with pack points.</label>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
             // scenario as being worth 1 one-star card instead of 2, the expectations end up being off by an average
             // of 1 one-star card per 377.92 packs. While I could make an effort to reduce this inaccuracy, I reckon
             // that error is less than the error of most users when estimating how many of their one-star cards were
-            // received via promos or wonder picks and/or how many of their one-star cards were converted into items.
+            // received via wonder picks and/or how many of their one-star cards were converted into items.
 
             if (numCards > packsOpened*5) {
                 resultElement.innerHTML = 'Those values seem suspiciously unlikely. Are you sure you entered them correctly?';


### PR DESCRIPTION
Promo cards don't have diamond or star rarity, "promo" is a searchable category in the rarity category.
This means that for the current purposes of this calculator, they can simply be ignored.

Anything involving promos would be its own separate calculator, as promo card pulls are easily separated from every other type of pull.